### PR TITLE
Bugfix in OctoAssociator.transform_events

### DIFF
--- a/src/pyocto/associator.py
+++ b/src/pyocto/associator.py
@@ -984,13 +984,13 @@ class OctoAssociator:
 
         events["latitude"] = events.apply(
             lambda x: self._transformer.transform(
-                x["x"] / factor, x["y"] / factor, direction="INVERSE"
+                x["x"] * factor, x["y"] * factor, direction="INVERSE"
             )[0],
             axis=1,
         )
         events["longitude"] = events.apply(
             lambda x: self._transformer.transform(
-                x["x"] / factor, x["y"] / factor, direction="INVERSE"
+                x["x"] * factor, x["y"] * factor, direction="INVERSE"
             )[1],
             axis=1,
         )


### PR DESCRIPTION
In OctoAssociator.transform_events the events are transformed back from local to global EPSG:4326 coordinates. In that course a  scaling of the local coordinates from kilometers to meters (or kilometers) takes place, which requires a _multiplication_ with the scaling factor of 1000 (or 1) rather than a _division_.

With this fix in place, correct event coordinates are obtained also in EPSG:4326.