### PR TITLE
Unpin numpy version and add a minor fix to the installation guide.

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ standard channels, such as `pip` or `conda`.
 git clone https://github.com/yetinam/pyocto.git
 cd pyocto
 git submodule update --init
-pip install .[test]
+pip install '.[test]'
 ```
 
 To verify your installation is working, use `pytest tests/`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = [
     { name = "My Name", email = "me@email.com" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,9 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "numpy>=1.21.6",
+    "numpy>=1.21.6,<3; python_version>'3.11'",   # numpy>2 is allowed for python>3.11
+    "numpy>=1.21.6,<2; python_version<='3.11'",  # numpy<2 is pinned for python<=3.11 due to Pyrocko incompatibility
     "pandas>=1.1",
-    "numpy<2",  # Pinned for now because there seems to be a Pyrocko incompatibility
     "pyproj",
 ]
 


### PR DESCRIPTION
(1) Since pyrocko has released the pin of numpy<2 for python>3.11 (see [pyrocko/pyproject.toml](https://github.com/pyrocko/pyrocko/blob/16e13074ad467bdf0437bffa81f0fcdc4d7eb7b5/pyproject.toml#L41-L42)), it time to release this pin in pyocto.

(2) Because the instatllation instruction in README.md: `pip install .[test]` breaks in the zsh shell, I added single quotation marks (`pip install '>[test]'`) to make it more robust (referr to this [the document](https://packaging.python.org/en/latest/tutorials/installing-packages/#installing-extras))